### PR TITLE
ci/adds auto labeler workflow for pull requests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,32 @@
+feature:
+  - head-branch: ["feature"]
+
+bugfix:
+  - head-branch: ["bugfix"]
+
+build:
+  - head-branch: ["build"]
+
+chore:
+  - head-branch: ["chore"]
+
+ci:
+  - head-branch: ["ci"]
+
+docs:
+  - head-branch: ["docs"]
+
+style:
+  - head-branch: ["style"]
+
+refactor:
+  - head-branch: ["refactor"]
+
+perf:
+  - head-branch: ["perf"]
+
+test:
+  - head-branch: ["test"]
+
+other:
+  - head-branch: ["other"]

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+  - pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5


### PR DESCRIPTION
Adds a [github pr labeler action](https://github.com/actions/labeler) that auto-labels pull requests based on whether the name of the branch that contains the changes you wish to merge (head branch) matches against certain regex expressions